### PR TITLE
[BUG]: App-analytics - fixed issue for app break on update chart

### DIFF
--- a/dashboards-observability/common/constants/explorer.ts
+++ b/dashboards-observability/common/constants/explorer.ts
@@ -80,7 +80,6 @@ export const REDUX_EXPL_SLICE_VISUALIZATION = 'explorerVisualization';
 export const REDUX_EXPL_SLICE_COUNT_DISTRIBUTION = 'countDistributionVisualization';
 export const PLOTLY_GAUGE_COLUMN_NUMBER = 4;
 export const APP_ANALYTICS_TAB_ID_REGEX = /application-analytics-tab.+/;
-export const DEFAULT_AVAILABILITY_QUERY = 'stats count() by span( timestamp, 1h )';
 export const ADD_BUTTON_TEXT = '+ Add color theme';
 export const NUMBER_INPUT_MIN_LIMIT = 1;
 

--- a/dashboards-observability/common/utils/query_utils.ts
+++ b/dashboards-observability/common/utils/query_utils.ts
@@ -59,7 +59,7 @@ export const buildQuery = (baseQuery: string, currQuery: string) => {
   if (baseQuery) {
     fullQuery = baseQuery;
     if (currQuery) {
-      fullQuery += '| ' + currQuery;
+      fullQuery += currQuery.trim().charAt(0) !== '|' ? '| ' : '' + currQuery;
     }
   } else {
     fullQuery = currQuery;

--- a/dashboards-observability/public/components/app.tsx
+++ b/dashboards-observability/public/components/app.tsx
@@ -73,6 +73,7 @@ export const App = ({
                       dslService={dslService}
                       savedObjects={savedObjects}
                       timestampUtils={timestampUtils}
+                      queryManager={queryManager}
                     />
                   );
                 }}

--- a/dashboards-observability/public/components/application_analytics/components/application.tsx
+++ b/dashboards-observability/public/components/application_analytics/components/application.tsx
@@ -66,6 +66,7 @@ import { ServiceDetailFlyout } from './flyout_components/service_detail_flyout';
 import { SpanDetailFlyout } from '../../../../public/components/trace_analytics/components/traces/span_detail_flyout';
 import { TraceDetailFlyout } from './flyout_components/trace_detail_flyout';
 import { fetchAppById, initializeTabData } from '../helpers/utils';
+import { QueryManager } from '../../../../common/query_manager/ppl_query_manager';
 
 const searchBarConfigs = {
   [TAB_EVENT_ID]: {
@@ -86,6 +87,7 @@ interface AppDetailProps extends AppAnalyticsComponentDeps {
   savedObjects: SavedObjects;
   timestampUtils: TimestampUtils;
   notifications: NotificationsStart;
+  queryManager: QueryManager;
   updateApp: (appId: string, updateAppData: Partial<ApplicationRequestType>, type: string) => void;
   setToasts: (title: string, color?: string, text?: ReactChild) => void;
   callback: (childfunction: () => void) => void;
@@ -110,6 +112,7 @@ export function Application(props: AppDetailProps) {
     setToasts,
     setFilters,
     callback,
+    queryManager,
   } = props;
   const [application, setApplication] = useState<ApplicationType>({
     id: '',
@@ -377,6 +380,7 @@ export function Application(props: AppDetailProps) {
         appBaseQuery={application.baseQuery}
         callback={callback}
         callbackInApp={callbackInApp}
+        queryManager={queryManager}
         curSelectedTabId={selectedTabId}
       />
     );

--- a/dashboards-observability/public/components/application_analytics/home.tsx
+++ b/dashboards-observability/public/components/application_analytics/home.tsx
@@ -38,6 +38,7 @@ import {
   CUSTOM_PANELS_API_PREFIX,
   CUSTOM_PANELS_DOCUMENTATION_URL,
 } from '../../../common/constants/custom_panels';
+import { QueryManager } from '../../../common/query_manager/ppl_query_manager';
 
 export type AppAnalyticsCoreDeps = TraceAnalyticsCoreDeps;
 
@@ -47,6 +48,7 @@ interface HomeProps extends RouteComponentProps, AppAnalyticsCoreDeps {
   savedObjects: SavedObjects;
   timestampUtils: TimestampUtils;
   notifications: NotificationsStart;
+  queryManager: QueryManager;
 }
 
 export interface AppAnalyticsComponentDeps extends TraceAnalyticsComponentDeps {
@@ -69,6 +71,7 @@ export const Home = (props: HomeProps) => {
     http,
     chrome,
     notifications,
+    queryManager,
   } = props;
   const [triggerSwitchToEvent, setTriggerSwitchToEvent] = useState(0);
   const dispatch = useDispatch();
@@ -435,6 +438,7 @@ export const Home = (props: HomeProps) => {
               setToasts={setToast}
               updateApp={updateApp}
               callback={callback}
+              queryManager={queryManager}
               {...commonProps}
             />
           )}

--- a/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/explorer.tsx
@@ -49,7 +49,6 @@ import {
   EVENT_ANALYTICS_DOCUMENTATION_URL,
   TAB_EVENT_ID,
   TAB_CHART_ID,
-  DEFAULT_AVAILABILITY_QUERY,
   DATE_PICKER_FORMAT,
   GROUPBY,
   AGGREGATIONS,
@@ -425,8 +424,8 @@ export const Explorer = ({
   const prepareAvailability = async () => {
     setSelectedContentTab(TAB_CHART_ID);
     setTriggerAvailability(true);
-    await setTempQuery(DEFAULT_AVAILABILITY_QUERY);
-    await updateQueryInStore(DEFAULT_AVAILABILITY_QUERY);
+    await setTempQuery('');
+    await updateQueryInStore('');
     await handleTimeRangePickerRefresh(true);
   };
 

--- a/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
+++ b/dashboards-observability/public/components/event_analytics/explorer/visualizations/config_panel/config_panes/config_controls/data_configurations_panel.tsx
@@ -194,7 +194,7 @@ export const DataConfigPanelItem = ({
             },
           })
         );
-        await fetchData(false);
+        await fetchData();
         await dispatch(
           changeVizConfig({
             tabId,

--- a/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
+++ b/dashboards-observability/public/components/visualizations/charts/helpers/viz_types.ts
@@ -85,7 +85,7 @@ const getStandardedOuiField = (name?: string, type?: string) => ({
 const defaultUserConfigs = (queryString, visualizationName: string) => {
   let tempUserConfigs = {};
   const qm = new QueryManager();
-  const statsTokens = qm.queryParser().parse(queryString.rawQuery).getStats();
+  const statsTokens = qm.queryParser().parse(queryString.finalQuery).getStats();
   if (!statsTokens) {
     tempUserConfigs = {
       [AGGREGATIONS]: [],


### PR DESCRIPTION
Signed-off-by: Dipra Aich <dipra_aich@persistent.com>

### Description
Application Analytics - App does not respond if configuration is added and Update Chart is clicked

### Issues Resolved
- Elimination of error on Update chart click
- Update of query into query search box on update chart click
- Restrict reset of configuration of update chart click
- Fetch and represent proper data on update chart click

[#1136](https://github.com/opensearch-project/observability/issues/1136)
 
### Check List
- [ ] Commits are signed per the DCO using --signoff
